### PR TITLE
Updated: Dockerfile to run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ FROM alpine:latest
 
 COPY --from=builder /scraper.dist /scraper.dist
 
-RUN chmod 0755 /scraper.dist/scraper
+RUN chmod g+rwX /scraper.dist/scraper
+
+USER 1001
 
 ENTRYPOINT ["/scraper.dist/scraper"]


### PR DESCRIPTION
Good day.
I have updated the Dockerfile to run as uid 1001. Running containers as root can be a security risk and should be avoided if possible.

Cheers :)